### PR TITLE
Open links in new window

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ docker run -it -e LEMMY_DOMAIN='lemmydomain.com' -p "8080:8080" ghcr.io/rystaf/m
 | LISTING | All |
 | SORT | Hot |
 | COMMENT_SORT | Hot |
+| LINKS_IN_NEW_WINDOW  | false |
 

--- a/routes.go
+++ b/routes.go
@@ -282,6 +282,8 @@ func Initialize(Host string, r *http.Request) (State, error) {
 	if state.Listing == "" || state.Session == nil && state.Listing == "Subscribed" {
 		state.Listing = getenv("LISTING", "All")
 	}
+	linksInNewWindowCookie := getCookie(r, "LinksInNewWindow")
+	state.LinksInNewWindow = linksInNewWindowCookie != "" && linksInNewWindowCookie != "0"
 	return state, nil
 }
 func GetTemplate(name string) (*template.Template, error) {

--- a/routes.go
+++ b/routes.go
@@ -282,8 +282,11 @@ func Initialize(Host string, r *http.Request) (State, error) {
 	if state.Listing == "" || state.Session == nil && state.Listing == "Subscribed" {
 		state.Listing = getenv("LISTING", "All")
 	}
-	linksInNewWindowCookie := getCookie(r, "LinksInNewWindow")
-	state.LinksInNewWindow = linksInNewWindowCookie != "" && linksInNewWindowCookie != "0"
+	if linksInNewWindow := getCookie(r, "LinksInNewWindow"); linksInNewWindow != "" {
+		state.LinksInNewWindow = linksInNewWindow != "0"
+	} else {
+		state.LinksInNewWindow = os.Getenv("LINKS_IN_NEW_WINDOW") != ""
+	}
 	return state, nil
 }
 func GetTemplate(name string) (*template.Template, error) {
@@ -766,6 +769,13 @@ func Settings(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		} else {
 			setCookie(w, "", "HideThumbnails", "0")
 			state.HideInstanceNames = false
+		}
+		if r.FormValue("linksInNewWindow") != "" {
+			setCookie(w, "", "LinksInNewWindow", "1")
+			state.LinksInNewWindow = true
+		} else {
+			setCookie(w, "", "LinksInNewWindow", "0")
+			state.LinksInNewWindow = false
 		}
 		state.Listing = r.FormValue("DefaultListingType")
 		state.Sort = r.FormValue("DefaultSortType")

--- a/state.go
+++ b/state.go
@@ -105,6 +105,7 @@ type State struct {
 	ShowNSFW          bool
 	HideInstanceNames bool
 	HideThumbnails    bool
+	LinksInNewWindow  bool
 	SubmitURL         string
 	SubmitTitle       string
 	SubmitBody        string

--- a/templates/post.html
+++ b/templates/post.html
@@ -25,14 +25,20 @@
         </div>
         {{ if not .State.HideThumbnails }}
         <div class="thumb">
-          <a class="url" href="{{ if .Post.URL.IsValid }}{{ .Post.URL }}{{ else }}/{{ .State.Host }}/post/{{ .Post.ID }}{{ end }}">
+          <a class="url"
+             href="{{ if .Post.URL.IsValid }}{{ .Post.URL }}{{ else }}/{{ .State.Host }}/post/{{ .Post.ID }}{{ end }}"
+             {{ if .State.LinksInNewWindow }}{{ target="_blank"}}>
             <div {{ if and .Post.NSFW (not (and .State.Community .State.Community.CommunityView.Community.NSFW))}}class="img-blur"{{end}} style="background-image: url({{thumbnail .Post}})"></div>
           </a>
         </div>
         {{ end }}
         <div class="entry">
           <div class="title">
-            <a class="url" href="{{ if .Post.URL.IsValid }}{{ .Post.URL }}{{ else }}/{{ .State.Host }}/post/{{ .Post.ID }}{{ end }}">{{ rmmarkdown .Post.Name }}</a>
+            <a class="url"
+               href="{{ if .Post.URL.IsValid }}{{ .Post.URL }}{{ else }}/{{ .State.Host }}/post/{{ .Post.ID }}{{ end }}"
+                {{ if .State.LinksInNewWindow }}{{ target="_blank"}}>
+                {{ rmmarkdown .Post.Name }}
+            </a>
             ({{ domain . }})
           </div>
           <div class="expando-button{{ if and (not (and .Post.Body.IsValid .Post.Body.String )) (not (isImage .Post.URL.String)) }} hidden{{else if eq .Rank 0}} open{{ end }}"></div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -27,7 +27,7 @@
         <div class="thumb">
           <a class="url"
              href="{{ if .Post.URL.IsValid }}{{ .Post.URL }}{{ else }}/{{ .State.Host }}/post/{{ .Post.ID }}{{ end }}"
-             {{ if .State.LinksInNewWindow }}{{ target="_blank"}}>
+             {{ if .State.LinksInNewWindow }} target="_blank" {{ end }}>
             <div {{ if and .Post.NSFW (not (and .State.Community .State.Community.CommunityView.Community.NSFW))}}class="img-blur"{{end}} style="background-image: url({{thumbnail .Post}})"></div>
           </a>
         </div>
@@ -36,7 +36,7 @@
           <div class="title">
             <a class="url"
                href="{{ if .Post.URL.IsValid }}{{ .Post.URL }}{{ else }}/{{ .State.Host }}/post/{{ .Post.ID }}{{ end }}"
-                {{ if .State.LinksInNewWindow }}{{ target="_blank"}}>
+                {{ if .State.LinksInNewWindow }} target="_blank" {{ end }}>
                 {{ rmmarkdown .Post.Name }}
             </a>
             ({{ domain . }})

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -131,6 +131,12 @@
         <input type="checkbox" name="hideThumbnails" {{ if .HideThumbnails }}checked{{end}}>
       </div>
       <div>
+        <label>
+          open links in new window
+        </label>
+        <input type="checkbox" name="linksInNewWindow" {{ if .LinksInNewWindow }}checked{{end}}>
+      </div>
+      <div>
         <label>lemmy: {{ .Site.Version }}<br><a href="https://github.com/rystaf/mlmym">mlmym</a>: {{ .Version }}</label>
         <input type="submit" value="save">
         {{ if .XHR }}<input id="closesettings" type="submit" value="close">{{ end }}


### PR DESCRIPTION
Adding a setting to opening links in a new window, with a check for environment variable LINKS_IN_NEW_WINDOW for the default value and a LinksInNewWindow cookie to save the value.
Opens links from posts' titles and thumbnails in a new window if selected.