### PR TITLE
Fixed published date formatting

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -49,7 +49,7 @@
 
 {{ if and .PostID .Posts }}
       <div class="stats">
-        this post was submitted on {{ (index .Posts 0).Post.Published.Time.Format "01 Jan 2006" }}
+        this post was submitted on {{ (index .Posts 0).Post.Published.Time.Format "02 Jan 2006" }}
         <div><b><span>{{ (index .Posts 0).Counts.Score }}</span> points</b> ({{likedPerc (index .Posts 0).Counts}}% liked)</div>
       </div>
 {{ end }}


### PR DESCRIPTION
I noticed a bug where, when viewing a post, the sidebar shows that the post was submitted on "month month year" as opposed to the intended (I assume) "day month year". Tweaking the format string resolves the issue.