### PR TITLE
Add curl to the container for healthcheck purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go build -v -o mlmym
 FROM debian:bullseye-slim
 WORKDIR /app
 RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    ca-certificates && \
+    ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/mlmym /app/mlmym
 COPY --from=builder /app/templates /app/templates


### PR DESCRIPTION
### Problem
The lemmy.world admins would like to have the ability to perform meaningful health checks in alt UI containers.

### Solution
This PR adds `curl` to the mlmym container for health check purposes.

### Testing Done
Confirmed container image build succeeds:
```
$ docker buildx build -t dvmlmym .
[+] Building 6.6s (21/21) FINISHED                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 650B                                                                               0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                            0.2s
 => [internal] load metadata for docker.io/library/golang:1.20-bullseye                                            0.2s
 => [builder 1/8] FROM docker.io/library/golang:1.20-bullseye@sha256:74e187ec10d10240e2e88542e75fe8da219d80dade50  0.0s
 => [internal] load build context                                                                                  0.2s
 => => transferring context: 4.08kB                                                                                0.2s
 => [stage-1 1/7] FROM docker.io/library/debian:bullseye-slim@sha256:c618be84fc82aa8ba203abbb07218410b0f5b3c7cb6b  0.0s
 => CACHED [builder 2/8] RUN git config --global --add safe.directory /app                                         0.0s
 => CACHED [builder 3/8] WORKDIR /app                                                                              0.0s
 => CACHED [builder 4/8] COPY go.* ./                                                                              0.0s
 => CACHED [builder 5/8] RUN go mod download                                                                       0.0s
 => [builder 6/8] COPY . ./                                                                                        0.0s
 => [builder 7/8] RUN git describe --tag > VERSION                                                                 0.2s
 => [builder 8/8] RUN go build -v -o mlmym                                                                         5.6s
 => CACHED [stage-1 2/7] WORKDIR /app                                                                              0.0s
 => CACHED [stage-1 3/7] RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y     ca  0.0s
 => [stage-1 4/7] COPY --from=builder /app/mlmym /app/mlmym                                                        0.1s
 => [stage-1 5/7] COPY --from=builder /app/templates /app/templates                                                0.0s
 => [stage-1 6/7] COPY --from=builder /app/public /app/public                                                      0.0s
 => [stage-1 7/7] COPY --from=builder /app/VERSION /app/VERSION                                                    0.0s
 => exporting to image                                                                                             0.1s
 => => exporting layers                                                                                            0.1s
 => => writing image sha256:3fe15e41b87a5a45b796ff66cb91c8459887adcd5df3b656204526b42f0a1424                       0.0s
 => => naming to docker.io/library/dvmlmym                                                                         0.0s
```

Running the container with a simple `curl` health check shows the correct health status for both a known-good Lemmy site and a non-existing one:
```
$ docker run -d -e LEMMY_DOMAIN=lemmy.world --name mlmym_good -p 8080:8080 --health-cmd 'curl -f http://127.0.0.1:8080 || exit 1' dvmlmym
bdbe76dd32e23b6ae0dc1adab1a5b4eebb83a3161587cac582850cdb94877ac0
$ docker run -d -e LEMMY_DOMAIN=doesnt.exist --name mlmym_bad -p 8081:8080 --health-cmd 'curl -f http://127.0.0.1:8080 || exit 1' dvmlmym
067d37bd9f618ddda3d5e1b045e970be7e852256c7d9401c17d0bf02bbccb82d
$ docker ps
CONTAINER ID   IMAGE     COMMAND                  CREATED         STATUS                     PORTS                                       NAMES
067d37bd9f61   dvmlmym   "./mlmym --addr 0.0.…"   2 minutes ago   Up 2 minutes (unhealthy)   0.0.0.0:8081->8080/tcp, :::8081->8080/tcp   mlmym_bad
bdbe76dd32e2   dvmlmym   "./mlmym --addr 0.0.…"   3 minutes ago   Up 3 minutes (healthy)     0.0.0.0:8080->8080/tcp, :::8080->8080/tcp   mlmym_good
```